### PR TITLE
Changes for FW 4.1.0 and 4.0.0

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -16,7 +16,7 @@ sd_loader_elf := ../sd_loader/sd_loader.elf
 CFLAGS += -DUSE_SD_LOADER
 ASFLAGS += -DUSE_SD_LOADER
 
-all: clean setup main532 main500
+all: clean setup main532 main500 main410 main400
 
 sd_loader.h: $(sd_loader_elf)
 	xxd -i $< | sed "s/unsigned/static const unsigned/g;s/loader/loader/g;s/build_//g" > $@

--- a/installer/kernel_patches.S
+++ b/installer/kernel_patches.S
@@ -27,8 +27,32 @@
 
     #define BAT_SET_NOP_ADDR_8          0xFFEE10B8
     #define BAT_SET_NOP_ADDR_9          0xFFEE10BC
-#elif ( (VER == 400) || (VER == 410) )
+#elif VER == 410
     #define BAT_SETUP_HOOK_ADDR         0xFFF1AD00
+
+    #define BAT_SET_NOP_ADDR_1          0xFFF06708
+    #define BAT_SET_NOP_ADDR_2          0xFFF06794
+    #define BAT_SET_NOP_ADDR_3          0xFFF003C8
+    #define BAT_SET_NOP_ADDR_4          0xFFF003CC
+    #define BAT_SET_NOP_ADDR_5          0xFFF1ADE8
+    #define BAT_SET_NOP_ADDR_6          0xFFF1AE04
+    #define BAT_SET_NOP_ADDR_7          0xFFF1AF08
+
+    #define BAT_SET_NOP_ADDR_8          0xFFEE10B8
+    #define BAT_SET_NOP_ADDR_9          0xFFEE10BC
+#elif VER == 400
+    #define BAT_SETUP_HOOK_ADDR         0xFFF1A440
+
+    #define BAT_SET_NOP_ADDR_1          0xFFF066FC
+    #define BAT_SET_NOP_ADDR_2          0xFFF06788
+    #define BAT_SET_NOP_ADDR_3          0xFFF003C8
+    #define BAT_SET_NOP_ADDR_4          0xFFF003CC
+    #define BAT_SET_NOP_ADDR_5          0xFFF1A528
+    #define BAT_SET_NOP_ADDR_6          0xFFF1A544
+    //define BAT_SET_NOP_ADDR_7          not present in 400
+
+    #define BAT_SET_NOP_ADDR_8          0xFFEE0F50
+    #define BAT_SET_NOP_ADDR_9          0xFFEE0F54
 #else
     #error Please define valid values for kernel setup.
 #endif

--- a/installer/launcher.c
+++ b/installer/launcher.c
@@ -35,6 +35,11 @@
 #elif ( (VER == 400) || (VER == 410) )
     #define ADDRESS_OSTitle_main_entry_ptr              0x1005A8C0
     #define ADDRESS_main_entry_hook                     0x0101BD4C
+
+    #define KERN_SYSCALL_TBL_1                          0xFFE84C90
+    #define KERN_SYSCALL_TBL_2                          0xFFE85090
+    #define KERN_SYSCALL_TBL_3                          0xFFE85C90
+    #define KERN_SYSCALL_TBL_4                          0xFFE85490
     #define KERN_SYSCALL_TBL_5                          0xFFE85890 // works with browser
 #endif // VER
 


### PR DESCRIPTION
- added addresses to kernel_patches.S and launcher.c
- updated installer makefile

Additional notes:
- KERN_SYSCALL_TBL 3 and 4 looks weird; especially for 4.0.0
  (would love to see if a third party could confirm those)
- tested on a WiiU with 4.1.0 only and works so far
- tested Homebrews were FTPiiU and Space Game