### PR TITLE
Add font smoothing

### DIFF
--- a/src/gui/FreeTypeGX.h
+++ b/src/gui/FreeTypeGX.h
@@ -134,14 +134,14 @@ class FreeTypeGX
 		uint16_t cacheGlyphDataComplete(int16_t pixelSize);
 		void loadGlyphData(FT_Bitmap *bmp, ftgxCharData *charData);
 
-		void copyTextureToFramebuffer(CVideo * pVideo, GX2Texture *tex, int16_t screenX, int16_t screenY, int16_t screenZ, const glm::vec4 & color, const float &textBlur, const float &colorBlurIntensity, const glm::vec4 & blurColor);
+		void copyTextureToFramebuffer(CVideo * pVideo, GX2Texture *tex, int16_t screenX, int16_t screenY, int16_t screenZ, const glm::vec4 & color, const float &textBlur, const float &colorBlurIntensity, const glm::vec4 & blurColor, const float & internalRenderingScale);
 
 	public:
 		FreeTypeGX(const uint8_t* fontBuffer, FT_Long bufferSize, bool lastFace = false);
 		~FreeTypeGX();
 
 		uint16_t drawText(CVideo * pVideo, int16_t x, int16_t y, int16_t z, const wchar_t *text, int16_t pixelSize, const glm::vec4 & color,
-                            uint16_t textStyling, uint16_t textWidth, const float &textBlur, const float &colorBlurIntensity, const glm::vec4 & blurColor);
+                            uint16_t textStyling, uint16_t textWidth, const float &textBlur, const float &colorBlurIntensity, const glm::vec4 & blurColor, const float & internalRenderingScale);
 
 		uint16_t getWidth(const wchar_t *text, int16_t pixelSize);
 		uint16_t getCharWidth(const wchar_t wChar, int16_t pixelSize, const wchar_t prevChar = 0x0000);

--- a/src/gui/GuiText.h
+++ b/src/gui/GuiText.h
@@ -104,6 +104,7 @@ protected:
     static FreeTypeGX * presentFont;
     static int presetSize;
     static int presetMaxWidth;
+    static int presetInternalRenderingScale;
     static int presetAlignment;
     static GX2ColorF32 presetColor;
 
@@ -134,6 +135,7 @@ protected:
     float blurGlowIntensity;
     float blurAlpha;
     glm::vec4 blurGlowColor;
+    float internalRenderingScale;
 };
 
 #endif


### PR DESCRIPTION
The changes here were entirely made by @Maschell. GuiText renders at a higher resolution and then scales down now, rather than a lower resolution and scaling up