### PR TITLE
Return to Wii U Menu if SELECT button is held down

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -17,6 +17,7 @@
 #include "Application.h"
 #include "common/common.h"
 #include "dynamic_libs/os_functions.h"
+#include "dynamic_libs/sys_functions.h"
 #include "gui/FreeTypeGX.h"
 #include "gui/VPadController.h"
 #include "gui/WPadController.h"
@@ -159,7 +160,11 @@ void Application::executeThread(void)
                 continue;
 
             if(controller[i]->data.buttons_d & VPAD_BUTTON_HOME)
+			{
+				if(controller[i]->data.buttons_h & VPAD_BUTTON_MINUS)
+					SYSLaunchMenu();
                 exitApplication = true;
+			}
 
             //! update controller states
             mainWindow->update(controller[i]);


### PR DESCRIPTION
If the SELECT button is being held down the moment the HOME button is
pressed, HBL will flag to the kernel that the program should exit to the
Wii U Menu, overriding the behaviour of sd_loader which re-launches Mii
Maker afterwards.