### PR TITLE
Exit: Home launches Wii U Menu, Minus launches Mii Maker

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -17,6 +17,7 @@
 #include "Application.h"
 #include "common/common.h"
 #include "dynamic_libs/os_functions.h"
+#include "dynamic_libs/sys_functions.h"
 #include "gui/FreeTypeGX.h"
 #include "gui/DVPadController.h"
 #include "gui/DWPadController.h"
@@ -168,8 +169,13 @@ void Application::executeThread(void)
             if(controller[i]->update(video->getTvWidth(), video->getTvHeight()) == false)
                 continue;
 
-            if(controller[i]->data.buttons_d & VPAD_BUTTON_HOME)
+            if(controller[i]->data.buttons_d & VPAD_BUTTON_MINUS)
                 exitApplication = true;
+            else if(controller[i]->data.buttons_d & VPAD_BUTTON_HOME)
+            {
+                SYSLaunchMenu();
+                exitApplication = true;
+            }
 
             //! update controller states
             mainWindow->update(controller[i]);

--- a/src/menu/HomebrewWindow.cpp
+++ b/src/menu/HomebrewWindow.cpp
@@ -43,6 +43,7 @@ HomebrewWindow::HomebrewWindow(int w, int h)
     , updownButtons(0, 0)
     , aButton(0, 0)
     , hblVersionText("Homebrew Launcher " HBL_VERSION " by Dimok", 32, glm::vec4(1.0f))
+    , miiMakerHintText("Press \ue046 to open Mii Maker", 26, glm::vec4(1.0f))
     , touchTrigger(GuiTrigger::CHANNEL_1, GuiTrigger::VPAD_TOUCH)
     , wpadTouchTrigger(GuiTrigger::CHANNEL_2 | GuiTrigger::CHANNEL_3 | GuiTrigger::CHANNEL_4 | GuiTrigger::CHANNEL_5, GuiTrigger::BUTTON_A)
     , buttonLTrigger(GuiTrigger::CHANNEL_ALL, GuiTrigger::BUTTON_L | GuiTrigger::BUTTON_LEFT | GuiTrigger::STICK_L_LEFT, true)
@@ -172,6 +173,17 @@ HomebrewWindow::HomebrewWindow(int w, int h)
         append(&arrowRightButton);
     }
 
+    void *font = NULL;
+    uint32_t size = 0;
+    OSGetSharedData(2, 0, (uint8_t*) &font, &size);
+
+    osFontSystem = new FreeTypeGX((uint8_t*) font, size, true);
+
+    miiMakerHintText.setFont(osFontSystem);
+    miiMakerHintText.setAlignment(ALIGN_BOTTOM | ALIGN_LEFT);
+    miiMakerHintText.setPosition(27, 36);
+    append(&miiMakerHintText);
+
     hblVersionText.setAlignment(ALIGN_BOTTOM | ALIGN_RIGHT);
     hblVersionText.setPosition(-30, 30);
     append(&hblVersionText);
@@ -206,6 +218,7 @@ HomebrewWindow::~HomebrewWindow()
     Resources::RemoveImageData(arrowRightImageData);
     Resources::RemoveImageData(arrowLeftImageData);
     Resources::RemoveImageData(homebrewButtonSelectedImageData);
+    delete osFontSystem;
 }
 
 void HomebrewWindow::OnOpenEffectFinish(GuiElement *element)

--- a/src/menu/HomebrewWindow.h
+++ b/src/menu/HomebrewWindow.h
@@ -74,6 +74,7 @@ private:
     GuiButton updownButtons;
     GuiButton aButton;
     GuiText hblVersionText;
+    GuiText miiMakerHintText;
 
     typedef struct
     {
@@ -102,6 +103,7 @@ private:
     TcpReceiver tcpReceiver;
 
     bool inputDisabled;
+    FreeTypeGX * osFontSystem;
 };
 
 #endif //_HOMEBREW_WINDOW_H_


### PR DESCRIPTION
@Fangal-Airbag proposed roughly this change in the Aroma Discord, adding "if anyone wants to PR that have fun!" So I'm having fun.

The original suggested change by Fangal-Airbag simply added Minus to launch the Wii U Menu, whereas this version does the following:

Home -> Wii U Menu
Minus -> Mii Maker

This might be a controversial change since Home has gone to Mii Maker for so long that people may be used to it behaving that way, but I hold pretty strongly that people naturally expect Home to allow them to quit, not reload into Mii Maker. In particular, users of the HBL channel are accustomed to using Home to quit. Most users only need Mii Maker fairly infrequently, so making it the secondary exit state seems reasonable to me.

I've been running this build locally for a few days and also posted it on Discord. No complaints so far.

Test build:
https://cdn.discordapp.com/attachments/433673797522948097/937288463986864258/homebrew_launcher.elf

Bonus test build, also includes #59:
https://cdn.discordapp.com/attachments/839753467056357376/938231179709149204/homebrew_launcher.elf

This PR is largely a dupe of #39, but uses different buttons to achieve the same thing.